### PR TITLE
fix: return a value from object find, not an entry

### DIFF
--- a/object/find.js
+++ b/object/find.js
@@ -1,4 +1,8 @@
 import entries from "./entries.js";
 
-export default predicate => xs =>
-  entries(xs).find(([key, value]) => predicate(value, key, xs));
+export default predicate => xs => {
+  const [, value] =
+    entries(xs).find(([key, value]) => predicate(value, key, xs)) || [];
+
+  return value;
+};


### PR DESCRIPTION
This matches behavior of [Array.prototype.find()
](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) as it returns a value, not a `[value, index]` pair.