### PR TITLE
fix: add simple test routine and add missing import extensions

### DIFF
--- a/date/displayMonth.js
+++ b/date/displayMonth.js
@@ -1,3 +1,3 @@
-import monthNames from "./monthNames";
+import monthNames from "./monthNames.js";
 
 export default monthIndex => monthNames[monthIndex % 12];

--- a/date/offsetByBit.js
+++ b/date/offsetByBit.js
@@ -1,4 +1,4 @@
-import fromSeconds from "./fromSeconds";
+import fromSeconds from "./fromSeconds.js";
 
 const SECOND = fromSeconds(1);
 

--- a/function/memoizeShallow.js
+++ b/function/memoizeShallow.js
@@ -1,4 +1,4 @@
-import memoizeWith from "./memoizeWith";
+import memoizeWith from "./memoizeWith.js";
 
 const equalsShallow = (xs, ys) =>
   xs.length === ys.length && xs.every((x, index) => x === ys[index]);

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,1 @@
+import "./index.js";

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prettier:check": "npm run prettier -- --check",
     "prettier:fix": "npm run prettier -- --write",
     "prettier": "prettier \"**/*.{js,json,md}\"",
-    "regenerate": "node --experimental-modules regenerate.js && npm run prettier:fix"
+    "regenerate": "node --experimental-modules regenerate.js && npm run prettier:fix",
+    "test": "node --experimental-modules index.test.js"
   },
   "repository": {
     "type": "git",

--- a/regenerate.js
+++ b/regenerate.js
@@ -15,6 +15,7 @@ const ignoredFiles = [
   ".npmignore",
   "index.cjs.js",
   "index.js",
+  "index.test.js",
   "index.umd.js",
   "LICENSE",
   "package-lock.json",


### PR DESCRIPTION
I have added a simple `npm test` script that verifies if the built module loads correctly. This pointed me to a few broken imports which have been fixed by the way.
This lets us use GitHub actions CI flow and Greenkeeper integration as now we can get build/test feedback.