### PR TITLE
fix: set node runtime version for CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sandstreamdev/std",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "type": "module",
   "module": "index.js",

--- a/regenerate.js
+++ b/regenerate.js
@@ -25,7 +25,7 @@ const ignoredFiles = [
   "rollup.config.js"
 ];
 
-const ignoredDirectories = [".git", "node_modules"];
+const ignoredDirectories = [".git", ".github", "node_modules"];
 
 const identifier = name => mapping[name] || name;
 


### PR DESCRIPTION
The build/test flow requires node 12+ as we use [--experimental-modules](https://nodejs.org/api/esm.html) flag.