### PR TITLE
Improve date validity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,6 +1199,8 @@ string[]
 
 #### valid
 
+Checks if the given date is a valid date.
+
 ##### Type signature
 
 <!-- prettier-ignore-start -->

--- a/README.md
+++ b/README.md
@@ -1199,7 +1199,7 @@ string[]
 
 #### valid
 
-Checks if the given date is a valid date.
+Checks if the given date is valid.
 
 ##### Type signature
 

--- a/date/README.md
+++ b/date/README.md
@@ -460,7 +460,7 @@ string[]
 
 # valid
 
-Checks if the given date is a valid date.
+Checks if the given date is valid.
 
 ## Type signature
 

--- a/date/README.md
+++ b/date/README.md
@@ -460,6 +460,8 @@ string[]
 
 # valid
 
+Checks if the given date is a valid date.
+
 ## Type signature
 
 <!-- prettier-ignore-start -->

--- a/date/valid.js
+++ b/date/valid.js
@@ -1,1 +1,2 @@
-export default date => (date ? date instanceof Date : false);
+export default date =>
+  date ? date instanceof Date && !Number.isNaN(date.valueOf()) : false;

--- a/date/valid.json
+++ b/date/valid.json
@@ -1,6 +1,6 @@
 {
   "name": "valid",
-  "description": "Checks if the given date is a valid date.",
+  "description": "Checks if the given date is valid.",
   "signature": "(date?: any) => boolean",
   "examples": [
     {

--- a/date/valid.json
+++ b/date/valid.json
@@ -1,6 +1,6 @@
 {
   "name": "valid",
-  "description": "TODO: Fill short description here.",
+  "description": "Checks if the given date is a valid date.",
   "signature": "(date?: any) => boolean",
   "examples": [
     {

--- a/date/valid.md
+++ b/date/valid.md
@@ -1,5 +1,7 @@
 # valid
 
+Checks if the given date is a valid date.
+
 ## Type signature
 
 <!-- prettier-ignore-start -->

--- a/date/valid.md
+++ b/date/valid.md
@@ -1,6 +1,6 @@
 # valid
 
-Checks if the given date is a valid date.
+Checks if the given date is valid.
 
 ## Type signature
 

--- a/date/valid.test.ts
+++ b/date/valid.test.ts
@@ -3,7 +3,18 @@
 import valid from "./valid.ts";
 
 describe("valid", () => {
-  it.skip("TODO", () => {
-    expect(valid()).toBeDefined();
+  it("checks if the given date is a valid date", () => {
+    expect(valid(new Date())).toBe(true);
+    expect(valid(new Date("2020-01-31T09:52:31.618Z"))).toBe(true);
+    expect(valid(new Date("77724e10-2ffa-45cc-b05d-a91a846a6080"))).toBe(false);
+  });
+
+  it("handles missing and falsy values", () => {
+    expect(valid(undefined)).toBe(false);
+    expect(valid(null)).toBe(false);
+    expect(valid(false)).toBe(false);
+    expect(valid(0)).toBe(false);
+    expect(valid(NaN)).toBe(false);
+    expect(valid("")).toBe(false);
   });
 });

--- a/date/valid.test.ts
+++ b/date/valid.test.ts
@@ -3,9 +3,13 @@
 import valid from "./valid.ts";
 
 describe("valid", () => {
-  it("checks if the given date is a valid date", () => {
+  it("checks if the given date is valid", () => {
     expect(valid(new Date())).toBe(true);
     expect(valid(new Date("2020-01-31T09:52:31.618Z"))).toBe(true);
+  });
+
+  it("should reject Invalid Date objects", () => {
+    expect(valid(new Date("test"))).toBe(false);
     expect(valid(new Date("77724e10-2ffa-45cc-b05d-a91a846a6080"))).toBe(false);
   });
 

--- a/date/valid.ts
+++ b/date/valid.ts
@@ -1,1 +1,2 @@
-export default (date?: any): boolean => (date ? date instanceof Date : false);
+export default (date?: any): boolean =>
+  date ? date instanceof Date && !Number.isNaN(date.valueOf()) : false;


### PR DESCRIPTION
`date/valid` now checks for `Invalid Date` objects that despite being instances of `Date` are invalid.