### PR TITLE
Fix object/map return value type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2173,7 +2173,7 @@ Maps the given object with the given function.
 <!-- prettier-ignore-start -->
 ```typescript
 (
-  f: (value: any, key: string, context: object) => boolean
+  f: (value: any, key: string, context: object) => any
 ) => (xs: object) => object
 ```
 <!-- prettier-ignore-end -->

--- a/object/README.md
+++ b/object/README.md
@@ -245,7 +245,7 @@ Maps the given object with the given function.
 <!-- prettier-ignore-start -->
 ```typescript
 (
-  f: (value: any, key: string, context: object) => boolean
+  f: (value: any, key: string, context: object) => any
 ) => (xs: object) => object
 ```
 <!-- prettier-ignore-end -->

--- a/object/map.json
+++ b/object/map.json
@@ -1,7 +1,7 @@
 {
   "name": "map",
   "description": "Maps the given object with the given function.",
-  "signature": "(\n  f: (value: any, key: string, context: object) => boolean\n) => (xs: object) => object",
+  "signature": "(\n  f: (value: any, key: string, context: object) => any\n) => (xs: object) => object",
   "examples": [
     {
       "language": "javascript",

--- a/object/map.md
+++ b/object/map.md
@@ -7,7 +7,7 @@ Maps the given object with the given function.
 <!-- prettier-ignore-start -->
 ```typescript
 (
-  f: (value: any, key: string, context: object) => boolean
+  f: (value: any, key: string, context: object) => any
 ) => (xs: object) => object
 ```
 <!-- prettier-ignore-end -->

--- a/object/map.ts
+++ b/object/map.ts
@@ -1,6 +1,6 @@
 import fromEntries from "./fromEntries";
 import mapEntries from "./mapEntries";
 
-export default (f: (value: any, key: string, context: object) => boolean) => (
+export default (f: (value: any, key: string, context: object) => any) => (
   xs: object
 ): object => fromEntries(mapEntries(f)(xs));


### PR DESCRIPTION
`object/map` had a broken return type assigned (`boolean` vs `any`). This PR fixes this and it is a candidate for a patch release.