### PR TITLE
Add object some and every functions to keep array parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2026,6 +2026,32 @@ Checks if two objects are deeply equal.
 ```
 <!-- prettier-ignore-end -->
 
+#### some
+
+Test if every element passes the given predicate.
+
+##### Type signature
+
+<!-- prettier-ignore-start -->
+```typescript
+(
+  f: (value: any, key: string, context: object) => boolean
+) => (xs: object) => boolean
+```
+<!-- prettier-ignore-end -->
+
+##### Examples
+
+<!-- prettier-ignore-start -->
+```javascript
+every(x => x >= 0)({ x: 5, y: 3, z: 0 }); // ⇒ true
+```
+
+```javascript
+every(x => x > 0)({ x: 5, y: 3, z: 0 }); // ⇒ false
+```
+<!-- prettier-ignore-end -->
+
 #### filter
 
 Filters the given object with the given predicate.
@@ -2268,6 +2294,32 @@ Checks if the given object is empty.
 <!-- prettier-ignore-start -->
 ```typescript
 (xs?: object) => boolean
+```
+<!-- prettier-ignore-end -->
+
+#### some
+
+Test if any element passes the given predicate.
+
+##### Type signature
+
+<!-- prettier-ignore-start -->
+```typescript
+(
+  f: (value: any, key: string, context: object) => boolean
+) => (xs: object) => boolean
+```
+<!-- prettier-ignore-end -->
+
+##### Examples
+
+<!-- prettier-ignore-start -->
+```javascript
+some(x => x >= 4)({ x: 5, y: 3, z: 0 }); // ⇒ true
+```
+
+```javascript
+some(x => x < 0)({ x: 5, y: 3, z: 0 }); // ⇒ false
 ```
 <!-- prettier-ignore-end -->
 

--- a/object/README.md
+++ b/object/README.md
@@ -98,6 +98,32 @@ Checks if two objects are deeply equal.
 ```
 <!-- prettier-ignore-end -->
 
+# some
+
+Test if every element passes the given predicate.
+
+## Type signature
+
+<!-- prettier-ignore-start -->
+```typescript
+(
+  f: (value: any, key: string, context: object) => boolean
+) => (xs: object) => boolean
+```
+<!-- prettier-ignore-end -->
+
+## Examples
+
+<!-- prettier-ignore-start -->
+```javascript
+every(x => x >= 0)({ x: 5, y: 3, z: 0 }); // ⇒ true
+```
+
+```javascript
+every(x => x > 0)({ x: 5, y: 3, z: 0 }); // ⇒ false
+```
+<!-- prettier-ignore-end -->
+
 # filter
 
 Filters the given object with the given predicate.
@@ -340,6 +366,32 @@ Checks if the given object is empty.
 <!-- prettier-ignore-start -->
 ```typescript
 (xs?: object) => boolean
+```
+<!-- prettier-ignore-end -->
+
+# some
+
+Test if any element passes the given predicate.
+
+## Type signature
+
+<!-- prettier-ignore-start -->
+```typescript
+(
+  f: (value: any, key: string, context: object) => boolean
+) => (xs: object) => boolean
+```
+<!-- prettier-ignore-end -->
+
+## Examples
+
+<!-- prettier-ignore-start -->
+```javascript
+some(x => x >= 4)({ x: 5, y: 3, z: 0 }); // ⇒ true
+```
+
+```javascript
+some(x => x < 0)({ x: 5, y: 3, z: 0 }); // ⇒ false
 ```
 <!-- prettier-ignore-end -->
 

--- a/object/every.js
+++ b/object/every.js
@@ -1,0 +1,4 @@
+import entries from "./entries.js";
+
+export default f => xs =>
+  entries(xs).every(([key, value]) => f(value, key, xs));

--- a/object/every.json
+++ b/object/every.json
@@ -1,0 +1,16 @@
+{
+  "name": "some",
+  "description": "Test if every element passes the given predicate.",
+  "signature": "(\n  f: (value: any, key: string, context: object) => boolean\n) => (xs: object) => boolean",
+  "examples": [
+    {
+      "language": "javascript",
+      "content": "every(x => x >= 0)({ x: 5, y: 3, z: 0 }); // ⇒ true"
+    },
+    {
+      "language": "javascript",
+      "content": "every(x => x > 0)({ x: 5, y: 3, z: 0 }); // ⇒ false"
+    }
+  ],
+  "questions": ["TODO: List questions that may this function answers."]
+}

--- a/object/every.md
+++ b/object/every.md
@@ -1,0 +1,25 @@
+# some
+
+Test if every element passes the given predicate.
+
+## Type signature
+
+<!-- prettier-ignore-start -->
+```typescript
+(
+  f: (value: any, key: string, context: object) => boolean
+) => (xs: object) => boolean
+```
+<!-- prettier-ignore-end -->
+
+## Examples
+
+<!-- prettier-ignore-start -->
+```javascript
+every(x => x >= 0)({ x: 5, y: 3, z: 0 }); // ⇒ true
+```
+
+```javascript
+every(x => x > 0)({ x: 5, y: 3, z: 0 }); // ⇒ false
+```
+<!-- prettier-ignore-end -->

--- a/object/every.test.ts
+++ b/object/every.test.ts
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+// @ts-ignore ambiguous import
+import every from "./every.ts";
+
+describe("every", () => {
+  it("test if every element passes the given predicate", () => {
+    const adult = ({ age }: { age: number }) => age >= 18;
+
+    expect(
+      every(adult)({
+        tom: { age: 25 },
+        john: { age: 16 },
+        alice: { age: 18 }
+      })
+    ).toBe(false);
+  });
+
+  it("test if every element passes the given predicate", () => {
+    expect(
+      every((x: number) => x >= 0)({
+        x: 5,
+        y: 3,
+        z: 0
+      })
+    ).toBe(true);
+  });
+});

--- a/object/every.ts
+++ b/object/every.ts
@@ -1,0 +1,5 @@
+import entries from "./entries";
+
+export default (f: (value: any, key: string, context: object) => boolean) => (
+  xs: object
+): boolean => entries(xs).every(([key, value]) => f(value, key, xs));

--- a/object/index.js
+++ b/object/index.js
@@ -4,6 +4,7 @@ import empty from "./empty.js";
 import entries from "./entries.js";
 import enumerable from "./enumerable.js";
 import equals from "./equals.js";
+import every from "./every.js";
 import filter from "./filter.js";
 import find from "./find.js";
 import findEntry from "./findEntry.js";
@@ -20,6 +21,7 @@ import mapKeys from "./mapKeys.js";
 import mapValues from "./mapValues.js";
 import merge from "./merge.js";
 import none from "./none.js";
+import some from "./some.js";
 import sort from "./sort.js";
 
 export {
@@ -29,6 +31,7 @@ export {
   entries,
   enumerable,
   equals,
+  every,
   filter,
   find,
   findEntry,
@@ -45,6 +48,7 @@ export {
   mapValues,
   merge,
   none,
+  some,
   sort
 };
 
@@ -55,6 +59,7 @@ export default {
   entries,
   enumerable,
   equals,
+  every,
   filter,
   find,
   findEntry,
@@ -71,5 +76,6 @@ export default {
   mapValues,
   merge,
   none,
+  some,
   sort
 };

--- a/object/index.ts
+++ b/object/index.ts
@@ -4,6 +4,7 @@ import empty from "./empty";
 import entries from "./entries";
 import enumerable from "./enumerable";
 import equals from "./equals";
+import every from "./every";
 import filter from "./filter";
 import find from "./find";
 import findEntry from "./findEntry";
@@ -20,6 +21,7 @@ import mapKeys from "./mapKeys";
 import mapValues from "./mapValues";
 import merge from "./merge";
 import none from "./none";
+import some from "./some";
 import sort from "./sort";
 
 export {
@@ -29,6 +31,7 @@ export {
   entries,
   enumerable,
   equals,
+  every,
   filter,
   find,
   findEntry,
@@ -45,6 +48,7 @@ export {
   mapValues,
   merge,
   none,
+  some,
   sort
 };
 
@@ -55,6 +59,7 @@ export default {
   entries,
   enumerable,
   equals,
+  every,
   filter,
   find,
   findEntry,
@@ -71,5 +76,6 @@ export default {
   mapValues,
   merge,
   none,
+  some,
   sort
 };

--- a/object/some.js
+++ b/object/some.js
@@ -1,0 +1,3 @@
+import entries from "./entries.js";
+
+export default f => xs => entries(xs).some(([key, value]) => f(value, key, xs));

--- a/object/some.json
+++ b/object/some.json
@@ -1,0 +1,16 @@
+{
+  "name": "some",
+  "description": "Test if any element passes the given predicate.",
+  "signature": "(\n  f: (value: any, key: string, context: object) => boolean\n) => (xs: object) => boolean",
+  "examples": [
+    {
+      "language": "javascript",
+      "content": "some(x => x >= 4)({ x: 5, y: 3, z: 0 }); // ⇒ true"
+    },
+    {
+      "language": "javascript",
+      "content": "some(x => x < 0)({ x: 5, y: 3, z: 0 }); // ⇒ false"
+    }
+  ],
+  "questions": ["TODO: List questions that may this function answers."]
+}

--- a/object/some.md
+++ b/object/some.md
@@ -1,0 +1,25 @@
+# some
+
+Test if any element passes the given predicate.
+
+## Type signature
+
+<!-- prettier-ignore-start -->
+```typescript
+(
+  f: (value: any, key: string, context: object) => boolean
+) => (xs: object) => boolean
+```
+<!-- prettier-ignore-end -->
+
+## Examples
+
+<!-- prettier-ignore-start -->
+```javascript
+some(x => x >= 4)({ x: 5, y: 3, z: 0 }); // ⇒ true
+```
+
+```javascript
+some(x => x < 0)({ x: 5, y: 3, z: 0 }); // ⇒ false
+```
+<!-- prettier-ignore-end -->

--- a/object/some.test.ts
+++ b/object/some.test.ts
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+// @ts-ignore ambiguous import
+import some from "./some.ts";
+
+describe("some", () => {
+  it("test if any element passes the given predicate", () => {
+    const adult = ({ age }: { age: number }) => age >= 18;
+
+    expect(
+      some(adult)({
+        tom: { age: 25 },
+        john: { age: 16 },
+        alice: { age: 18 }
+      })
+    ).toBe(true);
+  });
+
+  it("test if any element passes the given predicate", () => {
+    expect(
+      some((x: number) => x < 0)({
+        x: 5,
+        y: 3,
+        z: 0
+      })
+    ).toBe(false);
+  });
+});

--- a/object/some.ts
+++ b/object/some.ts
@@ -1,0 +1,5 @@
+import entries from "./entries";
+
+export default (f: (value: any, key: string, context: object) => boolean) => (
+  xs: object
+): boolean => entries(xs).some(([key, value]) => f(value, key, xs));


### PR DESCRIPTION
I have found a common pattern of `Object.values(xs).some(f)` and the same with `every` calls. They are now included as object modules to keep parity with arrays.