### PR TITLE
Enable code coverage reporting

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,4 +26,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.6
         with:
+          token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage/clover.xml

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -12,15 +11,19 @@ jobs:
         node-version: [12.x]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: npm ci, build, and test
-      run: |
-        npm ci
-        npm run build --if-present
-        npm test
-      env:
-        CI: true
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm ci, build, and test
+        run: |
+          npm ci
+          npm run build --if-present
+          npm test
+        env:
+          CI: true
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.0.6
+        with:
+          file: ./coverage/clover.xml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # std
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/sandstreamdev/std.svg)](https://greenkeeper.io/)
+[![Codecov](https://codecov.io/gh/sandstreamdev/std/branch/master/graph/badge.svg)](https://codecov.io/gh/sandstreamdev/std)
 [![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
 
 ## Installation


### PR DESCRIPTION
This PR enabled Codecov integration in a similar way as [react-swipeable-list](https://github.com/sandstreamdev/react-swipeable-list). Coverage reports are now uploaded to Codecov using GitHub Actions.

Hopefully, we will get a nice badge and coverage status right within PRs!